### PR TITLE
Flaky test is fixed by adding JsonPropertyOrder

### DIFF
--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ImmutablesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ImmutablesTest.java
@@ -1,6 +1,7 @@
 
 package cz.habarta.typescript.generator;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -59,6 +60,7 @@ public class ImmutablesTest {
 
     @Value.Immutable
     @JsonSerialize(as = ImmutableRectangle.class)
+    @JsonPropertyOrder({"width", "height"})
     @JsonDeserialize(as = ImmutableRectangle.class)
     public static abstract class Rectangle implements Shape {
         public abstract double width();


### PR DESCRIPTION
- The `testImmutables` method in `ImmutablesTest` can fail if the order of fields in `getDeclaredField` changes. I found this issue using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

* The command ```mvn -pl typescript-generator-core edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=cz.habarta.typescript.generator.ImmutablesTest#testImmutables -DnondexRuns=10``` runs the test 10 times and results in 5 failures in my JVM.

- After the executions, there was only a problem that caused all the errors: the width and height properties were replacing in the result string. For instance, the result can contain:

     "interface Rectangle extends Shape {\n" +
                    "    kind: 'rectangle';\n" +
                    "    width: number;\n" +
                    "    height: number;\n" +
                "}\n"   or,

     "interface Rectangle extends Shape {\n" +
                    "    kind: 'rectangle';\n" +
                    "    height: number;\n"  +
                    "    width: number;\n" +
                "}\n"

- To prevent such failures, the order of the properties could be specified using JsonPropertyOrder. 

-  After this change, the test passed in all 10 runs with ```mvn -pl typescript-generator-core edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=cz.habarta.typescript.generator.ImmutablesTest#testImmutables -DnondexRuns=10```.